### PR TITLE
Remove vimage-app remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ AAC at 128 kbps.
 
 ## Installation
 
-1. Navigate in your repo folder: cd `vimage-app`
+1. Navigate in your repo folder: cd `k-aura_stabilizer`
 2. Install project dependencies: `npm install`
 3. Create a new .env file: `cp .env.example .env`
 4. `VUE_APP_BASE_URL` should contain the URL of your App
@@ -47,7 +47,7 @@ Register a user from `#/register` or login using pre-created users.
 Within the download you'll find the following directories and files:
 
 ```
-vimage-app
+k-aura_stabilizer
     ├── index.html 
     ├── public
     │   ├── layout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: vimage-app
+    container_name: k-aura-app
     restart: always
     ports:
       - "8080:8080"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-image-upload-app",
+  "name": "k-aura-stabilizer",
   "version": "1.0.0",
   "private": true,
   "author": "Yani",
@@ -7,11 +7,11 @@
   "description": "Image AI app",
   "homepage": "",
   "bugs": {
-    "url": "https://github.com/janiluuk/vimage/issues"
+    "url": "https://github.com/janiluuk/k-aura_stabilizer/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://bitbucket.org/janiluuk/vimage-app.git"
+    "url": "git+https://github.com/janiluuk/k-aura_stabilizer.git"
   },
   "scripts": {
     "serve": "vite --cors --port 8080 --host --cors",


### PR DESCRIPTION
## Summary
- rename package and repository fields to k-aura-stabilizer
- update docker container and docs to remove vimage-app references

## Testing
- `npm install` *(fails: node-waf: not found while building zlib)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c91d94d608326ac8cdcba8baf5911